### PR TITLE
paramiko requires python-crypto

### DIFF
--- a/setup.hint
+++ b/setup.hint
@@ -4,4 +4,4 @@ Emphasis is on using SSH2 as an alternative to SSL for making secure
 connections between python scripts. All major ciphers and hash methods
 are supported. SFTP client and server mode are both supported too."
 category: Libs Python
-requires: python
+requires: python python-crypto


### PR DESCRIPTION
Without python-crypto, 'import paramiko' will fail.
